### PR TITLE
Add scraping and cron runner

### DIFF
--- a/app/api/check-items/route.ts
+++ b/app/api/check-items/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { getTrackedUrls, getRecentItemIds, addTrackedItem } from "@/lib/database"
+import * as cheerio from "cheerio"
 
 // This would be called by a cron job or webhook
 export async function POST(request: NextRequest) {
@@ -43,25 +44,64 @@ export async function POST(request: NextRequest) {
   }
 }
 
-// Placeholder function - in reality, you'd need proper web scraping
-// This would require handling CORS, anti-bot measures, etc.
+// Basic scraping implementation using fetch and cheerio
+// This parses the Vinted search results page and returns the first
+// two items found. It is intentionally simple and may require
+// adjustments if Vinted changes their markup or introduces additional
+// anti scraping measures.
+
 async function scrapeVintedUrl(url: string) {
-  // This is a simplified placeholder
-  // In a real implementation, you'd use a service like:
-  // - Puppeteer/Playwright for browser automation
-  // - A proxy service to avoid blocking
-  // - Proper parsing of Vinted's HTML structure
-
-  console.log(`Would scrape: ${url}`)
-
-  // Return mock data for demonstration
-  return [
-    {
-      item_id: `mock_${Date.now()}`,
-      title: "Sample Item",
-      subtitle: "Size M",
-      price: "£25.00",
-      item_url: "https://www.vinted.co.uk/items/sample",
+  const res = await fetch(url, {
+    headers: {
+      // Pretend to be a regular browser to avoid easy blocking
+      "User-Agent":
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122 Safari/537.36",
     },
-  ]
+  })
+
+  if (!res.ok) {
+    throw new Error(`Request failed with status ${res.status}`)
+  }
+
+  const html = await res.text()
+  const $ = cheerio.load(html)
+  const items: {
+    item_id: string
+    title?: string
+    subtitle?: string
+    price?: string
+    item_url?: string
+  }[] = []
+
+  $("div.feed-grid__item").each((i, el) => {
+    if (i >= 2) return false
+
+    const container = $(el).find("div.new-item-box__container")
+    if (!container.length) return
+
+    const dataTestId = container.attr("data-testid") || ""
+    const itemId = dataTestId.split("-").pop() || ""
+
+    let itemUrl = container.find("a[href]").attr("href") || ""
+    if (itemUrl && !itemUrl.startsWith("http")) {
+      itemUrl = `https://www.vinted.co.uk${itemUrl}`
+    }
+
+    const title = container
+      .find("p[data-testid$='--description-title']")
+      .text()
+      .trim()
+    const subtitle = container
+      .find("p[data-testid$='--description-subtitle']")
+      .text()
+      .trim()
+    const price = container
+      .find("p[data-testid$='--price-text']")
+      .text()
+      .trim()
+
+    items.push({ item_id: itemId, title, subtitle, price, item_url: itemUrl })
+  })
+
+  return items
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "cron": "node scripts/cron-check-items.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -42,6 +43,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "latest",
+    "cheerio": "^1.0.0-rc.12",
     "date-fns": "4.1.0",
     "embla-carousel-react": "latest",
     "input-otp": "latest",

--- a/scripts/cron-check-items.mjs
+++ b/scripts/cron-check-items.mjs
@@ -1,0 +1,22 @@
+const CHECK_URL = process.env.CHECK_URL || 'http://localhost:3000/api/check-items';
+const NOTIFY_URL = process.env.NOTIFY_URL || 'http://localhost:3000/api/notify';
+
+async function runCheck() {
+  try {
+    const res = await fetch(CHECK_URL, { method: 'POST' });
+    const data = await res.json();
+    console.log(new Date().toISOString(), `checked: ${data.newItems} new`);
+    if (data.items && data.items.length) {
+      await fetch(NOTIFY_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ items: data.items }),
+      });
+    }
+  } catch (err) {
+    console.error('Error running check-items cron', err);
+  }
+}
+
+runCheck();
+setInterval(runCheck, 30 * 1000);


### PR DESCRIPTION
## Summary
- implement real scraping via cheerio
- add cron script that posts to `/api/check-items` every 30s
- expose new `cron` npm script
- add `cheerio` dependency

## Testing
- `pnpm lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c74599094832ab0db9e658f01bd9a